### PR TITLE
manifest.json を作成した

### DIFF
--- a/docs/development-todos.md
+++ b/docs/development-todos.md
@@ -63,34 +63,34 @@
 ## フェーズ2: マニフェストファイルとアイコンの準備
 
 ### 2.1 manifest.jsonの作成
-- [ ] `public/manifest.json`の作成
-- [ ] 基本情報の設定
-  - [ ] `manifest_version: 3`の設定
-  - [ ] `name: "Light/Dark Mode Toggle"`の設定
-  - [ ] `version: "1.0.0"`の設定
-  - [ ] `description`の設定
-- [ ] 権限設定
-  - [ ] `permissions: ["storage", "activeTab"]`の設定
-  - [ ] `host_permissions: ["<all_urls>"]`の設定
-- [ ] セキュリティポリシーの設定
-  - [ ] `content_security_policy`の設定
-- [ ] バックグラウンドスクリプトの設定
-  - [ ] `background.service_worker: "background.js"`の設定
-  - [ ] `background.type: "module"`の設定
-- [ ] コンテンツスクリプトの設定
-  - [ ] `content_scripts`配列の作成
-  - [ ] `matches: ["<all_urls>"]`の設定
-  - [ ] `js: ["content.js"]`の設定
-  - [ ] `run_at: "document_start"`の設定
-  - [ ] `all_frames: false`の設定
-  - [ ] 注意: `css`フィールドは不要（ブラウザのネイティブ機能のみ使用）
-- [ ] アクション設定
-  - [ ] `action.default_popup: "popup.html"`の設定
-  - [ ] `action.default_icon`の設定（16, 48, 128）
-- [ ] アイコン設定
-  - [ ] `icons`の設定（16, 48, 128）
-- [ ] その他の設定
-  - [ ] `web_accessible_resources: []`の設定
+- [x] `public/manifest.json`の作成
+- [x] 基本情報の設定
+  - [x] `manifest_version: 3`の設定
+  - [x] `name: "Light/Dark Mode Toggle"`の設定
+  - [x] `version: "1.0.0"`の設定
+  - [x] `description`の設定
+- [x] 権限設定
+  - [x] `permissions: ["storage", "activeTab"]`の設定
+  - [x] `host_permissions: ["<all_urls>"]`の設定
+- [x] セキュリティポリシーの設定
+  - [x] `content_security_policy`の設定
+- [x] バックグラウンドスクリプトの設定
+  - [x] `background.service_worker: "background.js"`の設定
+  - [x] `background.type: "module"`の設定
+- [x] コンテンツスクリプトの設定
+  - [x] `content_scripts`配列の作成
+  - [x] `matches: ["<all_urls>"]`の設定
+  - [x] `js: ["content.js"]`の設定
+  - [x] `run_at: "document_start"`の設定
+  - [x] `all_frames: false`の設定
+  - [x] 注意: `css`フィールドは不要（ブラウザのネイティブ機能のみ使用）
+- [x] アクション設定
+  - [x] `action.default_popup: "popup.html"`の設定
+  - [x] `action.default_icon`の設定（16, 48, 128）
+- [x] アイコン設定
+  - [x] `icons`の設定（16, 48, 128）
+- [x] その他の設定
+  - [x] `web_accessible_resources: []`の設定
 
 ### 2.2 アイコンの準備
 - [ ] アイコンデザインの作成または取得

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,46 @@
+{
+  "manifest_version": 3,
+  "name": "Light/Dark Mode Toggle",
+  "version": "1.0.0",
+  "description": "Web上のどの画面でもライト/ダークモードを切り替え",
+  "permissions": [
+    "storage",
+    "activeTab"
+  ],
+  "host_permissions": [
+    "<all_urls>"
+  ],
+  "content_security_policy": {
+    "extension_pages": "script-src 'self'; object-src 'self'"
+  },
+  "background": {
+    "service_worker": "background.js",
+    "type": "module"
+  },
+  "content_scripts": [
+    {
+      "matches": [
+        "<all_urls>"
+      ],
+      "js": [
+        "content.js"
+      ],
+      "run_at": "document_start",
+      "all_frames": false
+    }
+  ],
+  "action": {
+    "default_popup": "popup.html",
+    "default_icon": {
+      "16": "icons/icon16.png",
+      "48": "icons/icon48.png",
+      "128": "icons/icon128.png"
+    }
+  },
+  "icons": {
+    "16": "icons/icon16.png",
+    "48": "icons/icon48.png",
+    "128": "icons/icon128.png"
+  },
+  "web_accessible_resources": []
+}


### PR DESCRIPTION
## 変更内容
Chrome拡張機能「Light/Dark Mode Toggle」の `manifest.json` を作成し、開発TODOドキュメント（フェーズ2の2.1）の項目を実装内容に合わせて更新しました。

## 完了条件
- `public/manifest.json` が作成されていること
- 以下の内容が `manifest.json` に定義されていること
  - `manifest_version: 3`
  - `name: "Light/Dark Mode Toggle"`
  - `version: "1.0.0"`
  - `description` に拡張機能の概要が記載されていること
  - `permissions: ["storage", "activeTab"]`
  - `host_permissions: ["<all_urls>"]`
  - `content_security_policy.extension_pages` が `"script-src 'self'; object-src 'self'"` となっていること
  - `background.service_worker: "background.js"` および `background.type: "module"` が設定されていること
  - `content_scripts` に `<all_urls>` 対象で `content.js` を `document_start` / `all_frames: false` で実行する設定があること
  - `action.default_popup: "popup.html"` が設定されていること
  - `action.default_icon` および `icons` に 16 / 48 / 128px のアイコンパスが設定されていること
  - `web_accessible_resources: []` が設定されていること
- `docs/development-todos.md` の「フェーズ2: 2.1 manifest.jsonの作成」のチェックリストが、今回の実装に合わせてすべて完了（`[x]`）になっていること

## 備考
- 現時点では `background.js` / `content.js` / `popup.html` 本体やアイコン画像ファイルは未実装であり、今後のフェーズで実装予定です。
- `manifest.json` の構成は `docs/manifest-guide.md` および `docs/development-todos.md` の内容に準拠しています。