### PR TITLE
[Phase3.1] 型定義の作成 (issue #9)

### DIFF
--- a/docs/development-todos.md
+++ b/docs/development-todos.md
@@ -106,16 +106,16 @@
 ## フェーズ3: 型定義と共通ユーティリティの実装
 
 ### 3.1 型定義の作成
-- [ ] `src/shared/types.ts`の作成
-  - [ ] `ThemeMode`型の定義（"light" | "dark"）
-  - [ ] `StorageData`インターフェースの定義
-    - [ ] `mode: ThemeMode`
-    - [ ] `enabled: boolean`
-  - [ ] `MessagePayload`インターフェースの定義
-    - [ ] `type: "TOGGLE_MODE" | "GET_MODE" | "APPLY_MODE"`
-    - [ ] `mode?: ThemeMode`
-- [ ] `src/background/types.ts`の作成（必要に応じて）
-- [ ] `src/vite-env.d.ts`の作成（Viteの型定義）
+- [x] `src/shared/types.ts`の作成
+  - [x] `ThemeMode`型の定義（"light" | "dark"）
+  - [x] `StorageData`インターフェースの定義
+    - [x] `mode: ThemeMode`
+    - [x] `enabled: boolean`
+  - [x] `MessagePayload`インターフェースの定義
+    - [x] `type: "TOGGLE_MODE" | "GET_MODE" | "APPLY_MODE"`
+    - [x] `mode?: ThemeMode`
+- [x] `src/background/types.ts`の作成（必要に応じて）
+- [x] `src/vite-env.d.ts`の作成（Viteの型定義）
 
 ### 3.2 ストレージユーティリティの実装
 - [ ] `src/shared/storage.ts`の作成

--- a/src/background/types.ts
+++ b/src/background/types.ts
@@ -1,0 +1,5 @@
+/**
+ * バックグラウンドスクリプト用の型定義
+ * 共通型は src/shared/types.ts から import して使用する
+ */
+export type { ThemeMode, StorageData, MessagePayload } from "../shared/types";

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1,0 +1,20 @@
+/**
+ * テーマモード（ライト / ダーク）
+ */
+export type ThemeMode = "light" | "dark";
+
+/**
+ * Chrome Storage に保存するデータの型
+ */
+export interface StorageData {
+  mode: ThemeMode;
+  enabled: boolean;
+}
+
+/**
+ * バックグラウンドスクリプト間のメッセージペイロード
+ */
+export interface MessagePayload {
+  type: "TOGGLE_MODE" | "GET_MODE" | "APPLY_MODE";
+  mode?: ThemeMode;
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
## 変更内容
フェーズ3.1: 拡張機能の型定義（ThemeMode, StorageData, MessagePayload）を `src/shared/types.ts` に作成し、`src/background/types.ts` と `src/vite-env.d.ts` を追加しました。

## 完了条件
- [x] `src/shared/types.ts`の作成
  - [x] `ThemeMode`型の定義（"light" | "dark"）
  - [x] `StorageData`インターフェースの定義
    - [x] `mode: ThemeMode`
    - [x] `enabled: boolean`
  - [x] `MessagePayload`インターフェースの定義
    - [x] `type: "TOGGLE_MODE" | "GET_MODE" | "APPLY_MODE"`
    - [x] `mode?: ThemeMode`
- [x] `src/background/types.ts`の作成（共通型を再エクスポート）
- [x] `src/vite-env.d.ts`の作成（Viteの型定義）

## 実装詳細
- `ThemeMode`: ライト/ダークのテーマモードを表すユニオン型
- `StorageData`: Chrome Storage に保存する mode / enabled のインターフェース
- `MessagePayload`: バックグラウンド間メッセージ用のペイロード型
- `src/background/types.ts` は `src/shared/types.ts` から型を再エクスポート（重複定義を避けるため）
- `development-todos.md` のフェーズ3.1のタスクを完了済みにマーク

## 備考
- 後続フェーズ（storage, messages, background など）でこれらの型を使用予定
- TypeScript の型安全性を確保済み

Closes #9