### PR TITLE
[Phase3] ストレージ/メッセージングユーティリティを実装する (issue #13)

### DIFF
--- a/docs/development-todos.md
+++ b/docs/development-todos.md
@@ -118,31 +118,31 @@
 - [x] `src/vite-env.d.ts`の作成（Viteの型定義）
 
 ### 3.2 ストレージユーティリティの実装
-- [ ] `src/shared/storage.ts`の作成
-- [ ] ストレージ読み込み関数の実装
-  - [ ] `getMode()`: 現在のモードを取得
-  - [ ] `getStorageData()`: ストレージデータ全体を取得
-- [ ] ストレージ書き込み関数の実装
-  - [ ] `setMode(mode: ThemeMode)`: モードを設定
-  - [ ] `toggleMode()`: モードを切り替え
-  - [ ] `setStorageData(data: StorageData)`: ストレージデータを設定
-- [ ] デフォルト値の設定
-  - [ ] 初回起動時のデフォルトモード（"light"）の設定
-- [ ] エラーハンドリングの実装
-  - [ ] `chrome.runtime.lastError`のチェック
-  - [ ] エラーログの出力
+- [x] `src/shared/storage.ts`の作成
+- [x] ストレージ読み込み関数の実装
+  - [x] `getMode()`: 現在のモードを取得
+  - [x] `getStorageData()`: ストレージデータ全体を取得
+- [x] ストレージ書き込み関数の実装
+  - [x] `setMode(mode: ThemeMode)`: モードを設定
+  - [x] `toggleMode()`: モードを切り替え
+  - [x] `setStorageData(data: StorageData)`: ストレージデータを設定
+- [x] デフォルト値の設定
+  - [x] 初回起動時のデフォルトモード（"light"）の設定
+- [x] エラーハンドリングの実装
+  - [x] `chrome.runtime.lastError`のチェック
+  - [x] エラーログの出力
 
 ### 3.3 メッセージングユーティリティの実装
-- [ ] `src/shared/messages.ts`の作成
-- [ ] メッセージ送信関数の実装
-  - [ ] `sendMessage<T>(message: MessagePayload): Promise<T>`
-  - [ ] エラーハンドリングの実装
-  - [ ] `chrome.runtime.lastError`のチェック
-- [ ] メッセージ受信リスナーの実装
-  - [ ] `onMessage(callback)`関数の実装
-  - [ ] 非同期処理対応（`true`を返して`sendResponse`を保持）
-- [ ] 型安全性の確保
-  - [ ] メッセージタイプの型チェック
+- [x] `src/shared/messages.ts`の作成
+- [x] メッセージ送信関数の実装
+  - [x] `sendMessage<T>(message: MessagePayload): Promise<T>`
+  - [x] エラーハンドリングの実装
+  - [x] `chrome.runtime.lastError`のチェック
+- [x] メッセージ受信リスナーの実装
+  - [x] `onMessage(callback)`関数の実装
+  - [x] 非同期処理対応（`true`を返して`sendResponse`を保持）
+- [x] 型安全性の確保
+  - [x] メッセージタイプの型チェック
 
 ---
 

--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -1,0 +1,74 @@
+/**
+ * Chrome Messaging API を用いたメッセージングユーティリティ
+ */
+
+import type { MessagePayload } from "./types";
+
+/**
+ * 拡張機能（バックグラウンドスクリプト）にメッセージを送信する
+ */
+export function sendMessage<T>(message: MessagePayload): Promise<T> {
+  return new Promise((resolve, reject) => {
+    chrome.runtime.sendMessage(message, (response) => {
+      if (chrome.runtime.lastError) {
+        console.error("[Light/Dark Toggle] Message error:", chrome.runtime.lastError);
+        reject(chrome.runtime.lastError);
+        return;
+      }
+      resolve(response as T);
+    });
+  });
+}
+
+/**
+ * メッセージ受信リスナーを登録する
+ * 非同期処理を行う場合は callback 内で true を返すこと（sendResponse を保持するため）
+ */
+export function onMessage(
+  callback: (
+    message: MessagePayload,
+    sender: chrome.runtime.MessageSender,
+    sendResponse: (response?: unknown) => void
+  ) => boolean | undefined | Promise<boolean | undefined>
+): void {
+  chrome.runtime.onMessage.addListener(
+    (
+      message: unknown,
+      sender: chrome.runtime.MessageSender,
+      sendResponse: (response?: unknown) => void
+    ) => {
+      // 型チェック: MessagePayload であることを検証
+      if (!isMessagePayload(message)) {
+        console.warn("[Light/Dark Toggle] Invalid message payload:", message);
+        sendResponse(undefined);
+        return false;
+      }
+      const result = callback(message, sender, sendResponse);
+      // Promise の場合は true を返して sendResponse を保持（コールバック内で sendResponse を呼ぶこと）
+      if (result instanceof Promise) {
+        result.catch((err) => {
+          console.error("[Light/Dark Toggle] Message handler error:", err);
+          sendResponse(undefined);
+        });
+        return true;
+      }
+      return result ?? false;
+    }
+  );
+}
+
+/**
+ * メッセージが MessagePayload 型かどうかを検証する
+ */
+function isMessagePayload(value: unknown): value is MessagePayload {
+  if (value === null || typeof value !== "object") {
+    return false;
+  }
+  const obj = value as Record<string, unknown>;
+  const validTypes = ["TOGGLE_MODE", "GET_MODE", "APPLY_MODE"];
+  return (
+    typeof obj.type === "string" &&
+    validTypes.includes(obj.type) &&
+    (obj.mode === undefined || obj.mode === "light" || obj.mode === "dark")
+  );
+}

--- a/src/shared/storage.ts
+++ b/src/shared/storage.ts
@@ -1,0 +1,73 @@
+/**
+ * Chrome Storage API を用いたストレージ操作ユーティリティ
+ */
+
+import type { StorageData, ThemeMode } from "./types";
+
+/** ストレージに保存するキー */
+const STORAGE_KEY = "theme";
+
+/** 初回起動時のデフォルト値 */
+const DEFAULT_STORAGE_DATA: StorageData = {
+  mode: "light",
+  enabled: true,
+};
+
+/**
+ * 現在のモードを取得する
+ */
+export async function getMode(): Promise<ThemeMode> {
+  const data = await getStorageData();
+  return data.mode;
+}
+
+/**
+ * ストレージデータ全体を取得する
+ */
+export async function getStorageData(): Promise<StorageData> {
+  return new Promise((resolve, reject) => {
+    chrome.storage.local.get(STORAGE_KEY, (result) => {
+      if (chrome.runtime.lastError) {
+        console.error("[Light/Dark Toggle] Storage get error:", chrome.runtime.lastError);
+        reject(chrome.runtime.lastError);
+        return;
+      }
+      const data = result[STORAGE_KEY] as StorageData | undefined;
+      resolve(data ?? { ...DEFAULT_STORAGE_DATA });
+    });
+  });
+}
+
+/**
+ * モードを設定する
+ */
+export async function setMode(mode: ThemeMode): Promise<void> {
+  const data = await getStorageData();
+  await setStorageData({ ...data, mode });
+}
+
+/**
+ * モードを切り替える（light ↔ dark）
+ */
+export async function toggleMode(): Promise<ThemeMode> {
+  const data = await getStorageData();
+  const newMode: ThemeMode = data.mode === "light" ? "dark" : "light";
+  await setStorageData({ ...data, mode: newMode });
+  return newMode;
+}
+
+/**
+ * ストレージデータを設定する
+ */
+export async function setStorageData(data: StorageData): Promise<void> {
+  return new Promise((resolve, reject) => {
+    chrome.storage.local.set({ [STORAGE_KEY]: data }, () => {
+      if (chrome.runtime.lastError) {
+        console.error("[Light/Dark Toggle] Storage set error:", chrome.runtime.lastError);
+        reject(chrome.runtime.lastError);
+        return;
+      }
+      resolve();
+    });
+  });
+}


### PR DESCRIPTION
## 変更内容
フェーズ3.2/3.3: Chrome Storage / Messaging API を扱うユーティリティを `src/shared/` に追加しました。

## 完了条件
- [x] `src/shared/storage.ts`の作成
- [x] ストレージ読み込み関数の実装
  - [x] `getMode()`
  - [x] `getStorageData()`
- [x] ストレージ書き込み関数の実装
  - [x] `setMode(mode: ThemeMode)`
  - [x] `toggleMode()`
  - [x] `setStorageData(data: StorageData)`
- [x] デフォルト値の設定（初回起動時は light / enabled: true）
- [x] `chrome.runtime.lastError` を考慮したエラーハンドリング
- [x] `src/shared/messages.ts`の作成
- [x] メッセージ送信/受信ユーティリティの実装
  - [x] `sendMessage<T>(message: MessagePayload): Promise<T>`
  - [x] `onMessage(callback)`（非同期対応）
- [x] `development-todos.md` の該当タスクを完了に更新

## 実装詳細
- `storage.ts`
  - `chrome.storage.local` を Promise 化
  - 未保存時はデフォルト値を返す
- `messages.ts`
  - `chrome.runtime.sendMessage` を Promise 化
  - 受信側で `MessagePayload` を型ガードし、不正ペイロードを弾く
  - `callback` が Promise を返すケースは `true` を返して `sendResponse` を保持

## 備考
- 後続フェーズで background/content/popup から共通に利用できる想定の土台

## Development
- #13

Closes #13

Made with [Cursor](https://cursor.com)